### PR TITLE
docs: fix Prerequisits -> Prerequisites typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Provides a "VPN" which tunnels all your device network traffic through Tor.
 
 ## Build
 
-### Prerequisits:
+### Prerequisites:
 - MacOS Sonoma or later
 - Xcode 15 or later
 - [Homebrew](https://brew.sh)


### PR DESCRIPTION
## Summary

Fixes a single-character typo in the Build section header of `README.md`:

\`\`\`diff
-### Prerequisits:
+### Prerequisites:
\`\`\`

## Verification

- `gitleaks` scan over the branch reports no leaks.
- A separate `chore:` commit on this branch adds standard secrets / credentials patterns to `.gitignore` (defense in depth; no impact on tracked files).

## Note

Co-developed with AI assistance; reviewed and tested by submitter.